### PR TITLE
Fix erroring directory shuffle

### DIFF
--- a/config/production/hugos.toml
+++ b/config/production/hugos.toml
@@ -1,2 +1,0 @@
-baseURL = "https://rladies.org/"
-disableLanguages = ["fr", "pt", "es"]

--- a/themes/hugo-rladies/layouts/partials/funcs/card-expand.html
+++ b/themes/hugo-rladies/layouts/partials/funcs/card-expand.html
@@ -6,12 +6,13 @@
 
 {{ $tags := slice }}
 {{ range $index, $item := . }}
-    {{ $replaced := replaceRE "[[:punct:]]" "," ($item | urlize) }}
+    {{ $item := $item | urlize | safeHTML}}
+    {{ $replaced := replaceRE "[[:punct:]]" "," ($item | safeHTML) }}
     {{ $split := split $replaced "," }}
     {{ $tags = $tags | append $split }}
 {{ end }}
 
-<li class="shuffle-item card-expand rounded card-{{ $size }} card" {{ with .id }} id="{{  . | htmlUnescape | urlize }}" {{ end }} {{ with .shuffle }} data-groups="[{{range  $index, $tags := . }}{{if ne $index 0}},{{end}}&quot;{{$tags | urlize}}&quot;{{ end }}]" {{ end}} >
+<li class="shuffle-item card-expand rounded card-{{ $size }} card" {{ with .id }} id="{{  . | htmlUnescape | urlize }}" {{ end }} data-groups="[{{ with .shuffle }} {{range  $index, $tags := . }}{{if ne $index 0}},{{end}}&quot;{{$tags | urlize}}&quot;{{ end }}{{ end}}]" >
   <div class="card-expand-img rounded-top">
     <img src="{{ $image }}"/>
   </div>

--- a/themes/hugo-rladies/layouts/partials/funcs/card-expand.html
+++ b/themes/hugo-rladies/layouts/partials/funcs/card-expand.html
@@ -6,8 +6,7 @@
 
 {{ $tags := slice }}
 {{ range $index, $item := . }}
-    {{ $item := $item | urlize | safeHTML}}
-    {{ $replaced := replaceRE "[[:punct:]]" "," ($item | safeHTML) }}
+    {{ $replaced := replaceRE "[[:punct:]]" "," ($item | urlize) }}
     {{ $split := split $replaced "," }}
     {{ $tags = $tags | append $split }}
 {{ end }}

--- a/themes/hugo-rladies/layouts/partials/funcs/directory/card.html
+++ b/themes/hugo-rladies/layouts/partials/funcs/directory/card.html
@@ -11,7 +11,6 @@
 {{ $dir.Set "subtitle" (printf "<p class=\"text-hide directory-id\">%s</p>" .name) }} 
 {{ with .data.work.title }} 
   {{ $dir.Add "subtitle" . }} 
-  {{ $dir.Add "shuffle" . }}
 {{ end }}
 
 {{ $grav := md5 ( .data.name | printf "%s-%s" .name ) }}
@@ -27,10 +26,6 @@
 {{ end }}
 
 {{ with .data.languages }}
-  {{ $dir.Add "shuffle" . }}
-{{ end }}
-
-{{ with .data.honorific }}
   {{ $dir.Add "shuffle" . }}
 {{ end }}
 


### PR DESCRIPTION
Narrowed down the problem. If a directory entry has no data to shuffle on (Dani Vasquez has something gone wrong with her entry exposing this), the neccessary data-group HTML attribute is not made, and it makes the shuffle plugin fail. 

I changed the code so that the data-group is initialized with an empty array, which makes it all work again.