### PR TITLE
Change Mastodon (and Twitter)

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -17,11 +17,17 @@ footerEnableTextWidget: true
 footerEnableLangWidget: true
 
 social:
+  - title: mastodon
+    url: 'https://hachyderm.io/@RLadiesGlobal'
+    icon: fab fa-mastodon
+    footer: true
+    sharethis: true
+    network: ''
   - title: twitter
     url: 'https://twitter.com/RLadiesGlobal'
     icon: fab fa-twitter-square
-    footer: true
-    sharethis: true
+    footer: false
+    sharethis: false
     network: twitter
   - title: instagram
     url: 'https://www.instagram.com/rladiesglobal'

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -18,49 +18,44 @@ footerEnableLangWidget: true
 
 social:
   - title: mastodon
-    url: 'https://hachyderm.io/@RLadiesGlobal'
-    icon: fab fa-mastodon
+    handle: '@RLadiesGlobal@hachyderm.io'
+    relme: true
     footer: true
     sharethis: true
     network: ''
   - title: twitter
-    url: 'https://twitter.com/RLadiesGlobal'
-    icon: fab fa-twitter-square
+    handle: 'RLadiesGlobal'
     footer: false
     sharethis: false
     network: twitter
   - title: instagram
-    url: 'https://www.instagram.com/rladiesglobal'
-    icon: fab fa-instagram
+    handle: 'rladiesglobal'
     footer: true
     sharethis: false
     network: ''
   - title: github
-    url: 'https://github.com/rladies'
-    icon: fab fa-github-square
+    handle: 'rladies'
     footer: true
     sharethis: false
     network: ''
   - title: meetup
-    url: 'https://www.meetup.com/pro/rladies/'
+    handle: 'pro/rladies/'
     footer: true
     sharethis: true
-    icon: fab fa-meetup
     network: ''
   - title: youtube
-    url: 'https://www.youtube.com/channel/UCDgj5-mFohWZ5irWSFMFcng'
+    handle: 'channel/UCDgj5-mFohWZ5irWSFMFcng'
     footer: true
     sharethis: true
-    icon: fab fa-youtube
     network: ''
 twitter:
   - title: We are R-Ladies
-    url: 'https://twitter.com/WeAreRLadies'
+    handle: 'WeAreRLadies'
     footer: true
     sharethis: false
     network: ''
   - title: IWD R-Ladies
-    url: 'https://twitter.com/rladies_iwd'
+    handle: 'rladies_iwd'
     footer: true
     sharethis: false
     network: ''

--- a/themes/hugo-rladies/layouts/partials/footer/footer.html
+++ b/themes/hugo-rladies/layouts/partials/footer/footer.html
@@ -26,7 +26,10 @@
   					<p class="follow-me-icons">
               {{ range .Site.Params.social }}
                   {{ if .footer }}
-                      <a href="{{ .url }}" target="_blank"><i class="{{ .icon }} fa-2x"></i></a>
+                    {{ $some:= partial "funcs/some.html" (dict "type" .title "handle" .handle ) }}
+                    <a href="{{ $some.url }}" target="_blank" {{ if .relme }} rel="me" {{ end }} >
+                      <i class="{{ $some.fa }} fa-2x"></i>
+                    </a>
                   {{ end }}
               {{ end }}
   					</p>

--- a/themes/hugo-rladies/layouts/partials/head/head.html
+++ b/themes/hugo-rladies/layouts/partials/head/head.html
@@ -20,3 +20,6 @@
 
 <!-- plausible -->
 <script defer data-domain="rladies.org" src="https://plausible.io/js/script.js"></script>
+
+<!-- Link for Mastodon -->
+<a href="https://hachyderm.io/@RLadiesGlobal" rel="me"></a>

--- a/themes/hugo-rladies/layouts/partials/head/head.html
+++ b/themes/hugo-rladies/layouts/partials/head/head.html
@@ -21,5 +21,3 @@
 <!-- plausible -->
 <script defer data-domain="rladies.org" src="https://plausible.io/js/script.js"></script>
 
-<!-- Link for Mastodon -->
-<a href="https://hachyderm.io/@RLadiesGlobal" rel="me"></a>


### PR DESCRIPTION
This PR addresses #209 

It
- adds the Mastodon verification (as I also implemented it on my website)
- removes Twitter (de-activated for now)  in the footer but kept the We Are R-Ladies and IWD R-Ladies as it was (see also comment [here](https://github.com/rladies/rladies.github.io/issues/209#issuecomment-1722562808))
- adds Mastodon in the footer

Before merging, we need to confirm that this is what we want ☺️