### PR TITLE
alternative way of adding hackyderm

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -18,49 +18,44 @@ footerEnableLangWidget: true
 
 social:
   - title: mastodon
-    url: 'https://hachyderm.io/@RLadiesGlobal'
-    icon: fab fa-mastodon
+    handle: '@RLadiesGlobal@hachyderm.io'
+    relme: true
     footer: true
     sharethis: true
     network: ''
   - title: twitter
-    url: 'https://twitter.com/RLadiesGlobal'
-    icon: fab fa-twitter-square
+    handle: 'RLadiesGlobal'
     footer: false
     sharethis: false
     network: twitter
   - title: instagram
-    url: 'https://www.instagram.com/rladiesglobal'
-    icon: fab fa-instagram
+    handle: 'rladiesglobal'
     footer: true
     sharethis: false
     network: ''
   - title: github
-    url: 'https://github.com/rladies'
-    icon: fab fa-github-square
+    handle: 'rladies'
     footer: true
     sharethis: false
     network: ''
   - title: meetup
-    url: 'https://www.meetup.com/pro/rladies/'
+    handle: 'pro/rladies/'
     footer: true
     sharethis: true
-    icon: fab fa-meetup
     network: ''
   - title: youtube
-    url: 'https://www.youtube.com/channel/UCDgj5-mFohWZ5irWSFMFcng'
+    handle: 'channel/UCDgj5-mFohWZ5irWSFMFcng'
     footer: true
     sharethis: true
-    icon: fab fa-youtube
     network: ''
 twitter:
   - title: We are R-Ladies
-    url: 'https://twitter.com/WeAreRLadies'
+    handle: 'WeAreRLadies'
     footer: true
     sharethis: false
     network: ''
   - title: IWD R-Ladies
-    url: 'https://twitter.com/rladies_iwd'
+    handle: 'rladies_iwd'
     footer: true
     sharethis: false
     network: ''

--- a/themes/hugo-rladies/layouts/partials/footer/footer.html
+++ b/themes/hugo-rladies/layouts/partials/footer/footer.html
@@ -26,7 +26,10 @@
   					<p class="follow-me-icons">
               {{ range .Site.Params.social }}
                   {{ if .footer }}
-                      <a href="{{ .url }}" target="_blank"><i class="{{ .icon }} fa-2x"></i></a>
+                    {{ $some:= partial "funcs/some.html" (dict "type" .title "handle" .handle ) }}
+                    <a href="{{ $some.url }}" target="_blank" {{ if .relme }} rel="me" {{ end }} >
+                      <i class="{{ $some.fa }} fa-2x"></i>
+                    </a>
                   {{ end }}
               {{ end }}
   					</p>

--- a/themes/hugo-rladies/layouts/partials/head/head.html
+++ b/themes/hugo-rladies/layouts/partials/head/head.html
@@ -21,5 +21,3 @@
 <!-- plausible -->
 <script defer data-domain="rladies.org" src="https://plausible.io/js/script.js"></script>
 
-<!-- Link for Mastodon -->
-<a href="https://hachyderm.io/@RLadiesGlobal" rel="me"></a>


### PR DESCRIPTION
in this version, I'm building on the existing tooling in thus hugo theme to add the relme tag to the mastodon handle at the bottom.

The idea behind this that we could also enable chapters with mastodon account to use the main rladies website to verify, if they do not have their own website. we dont do that now, but it can be quite easily implemented with this system.