### PR TITLE
Update R-Ladies Buenos Aires organizers list in argentina-buenos-aire…

### DIFF
--- a/data/chapters/argentina-buenos-aires-buenos-aires.json
+++ b/data/chapters/argentina-buenos-aires-buenos-aires.json
@@ -15,8 +15,8 @@
       "github": "rladies/meetup-presentations_buenosaires"
     },
     "organizers": {
-      "current": ["Paola Corrales", "Florencia D'Andrea", "Monica Alonso", "Priscilla Minotti", "Jimena Saucedo", "Maria Nanton", "Andrea Gomez", "Jesica Formoso", "Virginia Garc<ed>a Alonso"],
-      "former": []
+      "current": ["Maria Nanton", "Jesica Formoso", "Virginia Garc<ed>a Alonso", "Betsabé Cohen"],
+      "former": ["Laura Ación", "Paola Corrales", "Florencia D'Andrea", "Monica Alonso", "Priscilla Minotti", "Jimena Saucedo", "Verónica Rojo", "Andrea Gomez"]
     }
   }
 ]


### PR DESCRIPTION
This pull request updates the list of organizers for the R-Ladies Buenos Aires chapter to reflect recent changes in our local leadership team. We have included the current active organizers and removed those who are no longer part of the chapter's coordination.

Please let us know if any additional information is needed.

Thank you for maintaining this valuable resource!