### PR TITLE
style blockquotes (fix #423)

### DIFF
--- a/config/_default/markup.yaml
+++ b/config/_default/markup.yaml
@@ -3,5 +3,6 @@ defaultMarkdownHandler: "goldmark"
 goldmark:
   renderer:
     unsafe: true
-  
-  
+  parser:
+    attribute:
+      block: true

--- a/themes/hugo-rladies/assets/style.scss
+++ b/themes/hugo-rladies/assets/style.scss
@@ -868,3 +868,35 @@ tr.fc-list-event {
   transform: uppercase;
 }
 
+
+.blockquote {
+    padding: 60px 80px 40px;
+    position: relative;
+}
+.blockquote p {
+    font-size: 35px;
+    font-weight: 700px;
+    text-align: center;
+}
+
+.blockquote:before {
+  position: absolute;
+  font-family: 'FontAwesome';
+  top: 0;
+  
+  content:"\f10d";
+  font-size: 200px;
+  color: transparentize($primary, 0.9);
+}
+
+.blockquote::after {
+    content: "";
+    top: 20px;
+    left: 50%;
+    margin-left: -100px;
+    position: absolute;
+    border-bottom: 3px solid $primary;
+    height: 3px;
+    width: 200px;
+}
+

--- a/themes/hugo-rladies/layouts/_default/_markup/render-blockquote.html
+++ b/themes/hugo-rladies/layouts/_default/_markup/render-blockquote.html
@@ -1,0 +1,10 @@
+<figure class="mb-4">
+  <blockquote class="blockquote text-center " {{ with .Attributes.cite }}cite="{{ . }}"{{ end }}> 
+    {{ .Text }}
+  </blockquote>
+  {{ with .Attributes.caption }}
+    <figcaption class="blockquote-footer"> 
+      {{ . | safeHTML }}
+    </figcaption>
+  {{ end }}
+</figure>


### PR DESCRIPTION
One suggestion for a block quote.

<img width="1572" height="1134" alt="Screenshot 2025-07-19 at 16 50 35" src="https://github.com/user-attachments/assets/41218a0c-170c-4013-985b-df2180733f83" />
