### PR TITLE
add draft scripts for blog-airtable automation

### DIFF
--- a/scripts/blog-events.R
+++ b/scripts/blog-events.R
@@ -1,0 +1,94 @@
+library(airtabler)
+library(tidyverse)
+library(glue)
+library(readr)
+
+# Setup ----
+api_key <- Sys.setenv("AIRTABLE_API_KEY")
+base_id <- Sys.getenv("AIRTABLE_BASE_ID")
+table_name <- Sys.getenv("AIRTABLE_TABLE_ID")
+
+
+# Connect to base ----
+base <- airtable(base = base_id,
+                 tables = c("Proposals", "Event Reports"))
+
+# Get data ----
+events_data <- base$`Event Reports`$select()
+str(events_data)
+
+events_to_draft <- events_data %>%
+  filter(`Status` == "In progress", Decision == "Accept")
+
+# @Mo, I tried and failed all morning to make a Status column in the event report like the one in proposals.
+# I guess it could also have a manual toggle
+# From here it assumes there is a "Status" column)
+
+if (nrow(events_to_draft) == 0) {
+  print("No new event reports to draft")
+  quit()
+}
+
+print(paste("Found", nrow(events_to_draft), "new event report(s) to draft."))
+
+for (i in 1:nrow(events_to_draft)) {
+  
+  report <- events_to_draft[i, ]
+
+  slug <- report$title %>%
+    str_to_lower() %>%
+    str_replace_all("[^a-z0-9\\s-]", "") %>%
+    str_replace_all("\\s+", "-")
+  
+  # I use the *submission date* (`createdTime`) for the post date, 
+  # as the event `date` will always be in the past.
+  post_date <- ymd_hms(report$createdTime)
+  year <- year(post_date)
+  month_day_slug <- paste0(format(post_date, "%m-%d"), "-", slug)
+  
+  file_path <- file.path("content", "blog", year, month_day_slug)
+  
+  dir.create(file_path, recursive = TRUE, showWarnings = FALSE)
+  
+  # Markdown front-matter ----
+  front_matter <- glue(
+    '---
+    title: "Event Report: {report$title}"
+    author: "{report$author}"
+    date: "{format(post_date, "%Y-%m-%d")}"
+    tags: [{report$keywords}]
+    ---
+    
+    '
+  )
+  
+  # standardised blogpost
+  post_body <- glue(
+    'On {report$date}, {report$chapter} hosted the event "{report$title}". 
+    The session was led by {report$speakers} and was attended by {report$participants} participants.
+
+    ## Event Summary
+
+    Here are the key topics that were covered:
+
+    {report$summary}
+
+    ## Attendee Feedback
+
+    > {report$`Quotes or Reactions (optional)`}
+    
+    ## Resources
+
+    A big thank you to the speakers and everyone who attended!'
+  )
+
+  final_content <- paste0(front_matter, post_body)
+  final_file_name <- file.path(file_path, "index.en.md")
+  
+  writeLines(final_content, final_file_name)
+  
+  print(paste("Successfully created event report file:", final_file_name))
+  
+  # next: logic to update Airtable
+}
+

--- a/scripts/blog-proposal.R
+++ b/scripts/blog-proposal.R
@@ -1,0 +1,70 @@
+library(airtabler)
+library(tidyverse)
+library(glue)
+library(readr)
+
+# Setup ----
+api_key <- Sys.setenv("AIRTABLE_API_KEY")
+base_id <- Sys.getenv("AIRTABLE_BASE_ID")
+table_name <- Sys.getenv("AIRTABLE_TABLE_ID")
+
+# Connect to base ----
+base <- airtable(base = base_id,
+                 tables = c("Proposals", "Event Reports"))
+
+# Get data ----
+proposals_data <- base$Proposals$select()
+events_data <- base$`Event Reports`$select()
+
+str(proposals_data)
+str(events_data)
+
+proposals_to_draft <- proposals_data %>%
+  filter(`Status` == "In progress", Decision == "Accept")
+
+if (nrow(proposals_to_draft) == 0) {
+  print("No new proposals to draft.")
+  quit()
+}
+
+print(paste("Found", nrow(proposals_to_draft), "new proposal(s) to draft."))
+
+# Loop through the proposals and create md file ----
+for (i in 1:nrow(proposals_to_draft)) {
+  proposal <- proposals_to_draft
+  proposal <- proposals_to_draft[i, ]
+  
+  # "slug" from the title ---
+  slug <- proposal$Title %>%
+    str_to_lower() %>%
+    str_replace_all("[^a-z0-9\\s-]", "") %>%
+    str_replace_all("\\s+", "-")
+
+  post_date_obj <- ymd(proposal$`Post date`)
+  month_day <- format(post_date_obj, "%m-%d")
+  year <- year(post_date_obj)
+  final_name_part <- paste0(month_day, "_", slug)
+  
+  file_path <- file.path("content", "blog", year, final_name_part)
+  dir.create(file_path, recursive = TRUE, showWarnings = FALSE) # @Mo, recursive=TRUE to keep?
+  
+  # metadata for md file
+  front_matter <- glue::glue(
+    '---
+    title: "{proposal$Title}"
+    author: "{proposal$Author}"
+    date: "{proposal$`Post date`}"
+    ---
+    
+    '
+  )
+  body_content <- proposal$Description
+  blog_file <- file.path(file_path, "index.en.md")
+  
+  writeLines(paste0(front_matter, body_content), blog_file)
+  
+  print(paste("Successfully created draft file:", blog_file))
+  
+  # Next, logic to update Airtable?
+
+}


### PR DESCRIPTION
## Description
This PR introduces two new R scripts to automate the creation of blog post drafts from Airtable.
`scripts/blog-proposal.R`: handles general blog post proposals.
`scripts/blog-events.R`: handles event reports and formats them into a standardised post.

## To do List
[ ] Code review of logic and structure of `blog-proposal.R`
[ ] Code review of logic and structure of `blog-events.R`
[ ] Add Status column in Events report table in Airtable
[ ] API Key Setup: Add the AIRTABLE_API_KEY and other IDs for the GitHub Action to use
[ ] Add the final step in the scripts to update the Airtable record with the PR link and a new status.
[ ] GitHub Actions Workflow